### PR TITLE
docs: add TypeScript installation (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 Airbnb's ESLint config with TypeScript and Prettier support.
 
 # How to use
-Install `eslint` and `prettier`, `eslint-config-airbnb-typescript-prettier` and put it into your `.eslintrc.js`.
+Install `typescript`, `eslint` and `prettier`, `eslint-config-airbnb-typescript-prettier` and put it into your `.eslintrc.js`.
 
 ```bash
-$ npm install eslint@^6.8.0 prettier@^1.18.2 eslint-config-airbnb-typescript-prettier --save-dev
+$ npm install typescript@3.7.3 eslint@^6.8.0 prettier@^1.18.2 eslint-config-airbnb-typescript-prettier --save-dev
 ```
 
 `.eslintrc.js`


### PR DESCRIPTION
Add typescript to npm command.

I add specific version `3.7.3` because `typescript-eslint` has not supported Typescript 3.8 yet.