### PR TITLE
chore: use public repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/toshi-toma/eslint-config-airbnb-typescript-prettier.git"
+    "url": "git+https://github.com/toshi-toma/eslint-config-airbnb-typescript-prettier.git"
   },
   "engines": {
     "node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"


### PR DESCRIPTION
## Summary
- update the package repository URL from the SSH form to public `git+https://`
- leave runtime code, dependencies, package version, entry point, homepage, bugs metadata, and package contents unchanged

## Validation
- `npm view eslint-config-airbnb-typescript-prettier repository homepage bugs --json`
- `node` metadata assertion for package name, repository, homepage, and bugs URL
- `npm install --ignore-scripts --no-audit --no-fund --package-lock=false`
- `npm test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`
